### PR TITLE
Use overrides rather than property set in `mini.js`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,15 @@
 # @date-fns/utc
 
+---
+
+We forked the repo because the library [replaces][1] non-UTC methods with UTC ones using a property set, which is a prohibited operation within Temporal Workflows. The library was automatically inserted into the workflow bundle (by `bundle-workflows.cjs`) and a static check prevented the workflow from starting properly. This was the case even when the problematic line in the library wasn't evaluated in any part of the workflow.
+
+We replaced the `UTCDateMini` definition linked above with our own: [mini.js](src/date/mini.js). Rather than using property setting to replace non-UTC methods, our version uses method overrides over the `extend Date` class.
+
+[1]: https://github.com/date-fns/utc/blob/d2b7442216d72a5dbdc23519aef067d998c7c58b/src/date/mini.js#L27
+
+---
+
 The package provides `Date` extensions `UTCDate` and `UTCDateMini` that perform all calculations in UTC rather than the system time zone.
 
 Using it makes [date-fns] operate in UTC but can be also used without it.

--- a/src/date/mini.js
+++ b/src/date/mini.js
@@ -15,15 +15,66 @@ export class UTCDateMini extends Date {
   }
 
   getTimezoneOffset() {
-    return 0;
+    return 0
+  }
+
+  getFullYear() {
+    return this.getUTCFullYear()
+  }
+  
+  getMonth() {
+    return this.getUTCMonth()
+  }
+  
+  getDate() {
+    return this.getUTCDate()
+  }
+
+  getDay() {
+    return this.getUTCDay()
+  }
+
+  getHours() {
+    return this.getUTCHours()
+  }
+
+  getMinutes() {
+    return this.getUTCMinutes()
+  }
+
+  getSeconds() {
+    return this.getUTCSeconds()
+  }
+
+  getMilliseconds() {
+    return this.getUTCMilliseconds()
+  }
+
+  setFullYear(year, month, date) {
+    return this.setUTCFullYear(...arguments)
+  }
+
+  setMonth(month, date) {
+    return this.setUTCMonth(...arguments)
+  }
+
+  setDate(day) {
+    return this.setUTCDate(day)
+  }
+  
+  setHours(hours, minutes, seconds, ms) {
+    return this.setUTCHours(...arguments)
+  }
+  
+  setMinutes(minutes, seconds, ms) {
+    return this.setUTCMinutes(...arguments)
+  }
+
+  setSeconds(seconds, ms) {
+    return this.setUTCSeconds(...arguments)
+  }
+  
+  setMilliseconds(milliseconds) {
+    return this.setUTCMilliseconds(milliseconds)
   }
 }
-
-// Replace getter and setter functions with UTC counterparts
-const re = /^(get|set)(?!UTC)/;
-Object.getOwnPropertyNames(Date.prototype).forEach((method) => {
-  if (re.test(method)) {
-    const utcMethod = Date.prototype[method.replace(re, "$1UTC")];
-    if (utcMethod) UTCDateMini.prototype[method] = utcMethod;
-  }
-});


### PR DESCRIPTION
This definition of the `UTCDateMini` class should be functionally identical to the previous. However, this version is compatible with frozen (read-only) objects that make it workable with Temporal.io workflows.