### PR TITLE
PRO-2493 Create declaration files described in package.json

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ build: prepare-build
 	@env BABEL_ENV=cjs pnpm exec babel src --config-file ./babel.config.json --source-root src --out-dir lib --extensions .js,.ts --out-file-extension .cjs --quiet
 	@node copy.mjs
 	@make build-cts
+	@make copy-declarations
 	
 build-cts:
 	@find lib -name '*.d.ts' | while read file; do \
@@ -26,9 +27,23 @@ build-cts:
 		cp $$file $$new_file; \
 	done
 
+# New target to move declaration files to match package.json expectations
+copy-declarations:
+	@cp lib/index.d.ts ./index.d.ts
+	@cp lib/index.d.cts ./index.d.cts
+	@mkdir -p date utc
+	@cp lib/date/index.d.ts ./date/
+	@cp lib/date/index.d.cts ./date/
+	@cp lib/date/mini.d.ts ./date/
+	@cp lib/date/mini.d.cts ./date/
+	@cp lib/utc/index.d.ts ./utc/
+	@cp lib/utc/index.d.cts ./utc/
+
 prepare-build:
 	@rm -rf lib
 	@mkdir -p lib
+	@rm -f index.d.ts index.d.cts
+	@rm -rf date utc
 
 publish: build
 	@cd lib && pnpm publish --access public

--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ We replaced the `UTCDateMini` definition linked above with our own: [mini.js](sr
 
 [1]: https://github.com/date-fns/utc/blob/d2b7442216d72a5dbdc23519aef067d998c7c58b/src/date/mini.js#L27
 
+
+We also included some declaration file exports to the repo (which would otherwise be created at build time and published to the npm bundle) so they are directly
+accessible when the package is included as a dependency using a `github:` link.
+
+**If any further changes are made you must `pnpm build` and include changes to those files!**
+
 ---
 
 The package provides `Date` extensions `UTCDate` and `UTCDateMini` that perform all calculations in UTC rather than the system time zone.

--- a/date/index.d.cts
+++ b/date/index.d.cts
@@ -1,0 +1,17 @@
+/**
+ * UTC date class. It maps getters and setters to corresponding UTC methods,
+ * forcing all calculations in the UTC time zone.
+ *
+ * Combined with date-fns, it allows using the class the same way as
+ * the original date class.
+ *
+ * This complete version provides not only getters, setters,
+ * and `getTimezoneOffset`, but also the formatter functions, mirroring
+ * all original `Date` functionality. Use this version when you need to format
+ * a string or in an environment you don't fully control (a library).
+ *
+ * For a minimal version, see `UTCDateMini`.
+ */
+export class UTCDate extends Date {
+  getTimezoneOffset(): 0;
+}

--- a/date/index.d.ts
+++ b/date/index.d.ts
@@ -1,0 +1,17 @@
+/**
+ * UTC date class. It maps getters and setters to corresponding UTC methods,
+ * forcing all calculations in the UTC time zone.
+ *
+ * Combined with date-fns, it allows using the class the same way as
+ * the original date class.
+ *
+ * This complete version provides not only getters, setters,
+ * and `getTimezoneOffset`, but also the formatter functions, mirroring
+ * all original `Date` functionality. Use this version when you need to format
+ * a string or in an environment you don't fully control (a library).
+ *
+ * For a minimal version, see `UTCDateMini`.
+ */
+export class UTCDate extends Date {
+  getTimezoneOffset(): 0;
+}

--- a/date/mini.d.cts
+++ b/date/mini.d.cts
@@ -1,0 +1,15 @@
+import { type UTCDate } from "./index.ts";
+
+/**
+ * UTC date class. It maps getters and setters to corresponding UTC methods,
+ * forcing all calculations in the UTC time zone.
+ *
+ * Combined with date-fns, it allows using the class the same way as
+ * the original date class.
+ *
+ * This minimal version provides only getters, setters, and `getTimezoneOffset`,
+ * leaving the formatter functions out.
+ *
+ * For the complete version, see `UTCDate`.
+ */
+export const UTCDateMini: typeof UTCDate;

--- a/date/mini.d.ts
+++ b/date/mini.d.ts
@@ -1,0 +1,15 @@
+import { type UTCDate } from "./index.ts";
+
+/**
+ * UTC date class. It maps getters and setters to corresponding UTC methods,
+ * forcing all calculations in the UTC time zone.
+ *
+ * Combined with date-fns, it allows using the class the same way as
+ * the original date class.
+ *
+ * This minimal version provides only getters, setters, and `getTimezoneOffset`,
+ * leaving the formatter functions out.
+ *
+ * For the complete version, see `UTCDate`.
+ */
+export const UTCDateMini: typeof UTCDate;

--- a/index.d.cts
+++ b/index.d.cts
@@ -1,0 +1,3 @@
+export * from "./date/index.js";
+export * from "./date/mini.js";
+export * from "./utc/index.ts";

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,3 @@
+export * from "./date/index.js";
+export * from "./date/mini.js";
+export * from "./utc/index.ts";

--- a/utc/index.d.cts
+++ b/utc/index.d.cts
@@ -1,0 +1,10 @@
+import { UTCDate } from "../date/index.js";
+/**
+ * The function creates a new `UTCDate` instance from the provided value. Use it
+ * to provide the context for the date-fns functions, via the `in` option.
+ *
+ * @param value - Date value, timestamp, string or `Date` instance
+ *
+ * @returns UTCDate instance created from the provided value
+ */
+export declare const utc: (value: Date | number | string) => UTCDate;

--- a/utc/index.d.ts
+++ b/utc/index.d.ts
@@ -1,0 +1,10 @@
+import { UTCDate } from "../date/index.js";
+/**
+ * The function creates a new `UTCDate` instance from the provided value. Use it
+ * to provide the context for the date-fns functions, via the `in` option.
+ *
+ * @param value - Date value, timestamp, string or `Date` instance
+ *
+ * @returns UTCDate instance created from the provided value
+ */
+export declare const utc: (value: Date | number | string) => UTCDate;


### PR DESCRIPTION
The **published** bundle for this package includes various declaration files which are required for use of the module. However, when we reference the fork using a `github:` link the declaration files aren't there.

The files don't exist "natively" in the repo, but only in the published bundle. Why is that? The files are only created in a `pnpm build` and they are placed in `lib/`. This directory is not in the repo as it's `.gitignore`d (as it should be). Then, when a bundle is published to npm (using `pnpm publish`, also defined in the Makefile), we do so `cd`ed to `lib/`. The `package.json` file references the declaration files using relative paths, meaning these will **only** be found if you're already `cd`ed to `lib/`.

We don't want to publish our fork to npm, we just want to access it with the `github:` link style. This PR does something a little hacky but that I think we can live with. It adds those declaration files and saves them to paths that will be resolved with `package.json`'s relative paths **from the root directory**. This isn't all that crazy. Effectively, we're just making this repo take the same form as the 'published' bundle.

With these changes we can resolve the dependency, including its type declarations, with `github:` syntax from our own co2nado packages.